### PR TITLE
feat: Reduce function call overhead

### DIFF
--- a/XenonCode.hpp
+++ b/XenonCode.hpp
@@ -5792,6 +5792,8 @@ const int VERSION_PATCH = 0;
 		std::unordered_map<uint32_t/*24 least significant bits only*/, std::string> Device::deviceFunctionNamesById {};
 		std::unordered_map<uint32_t/*24 least significant bits only*/, DeviceFunction> Device::deviceFunctionsById {};
 		std::unordered_map<uint8_t, std::vector<std::string>> Device::deviceFunctionsList {};
+    std::unordered_map<uint32_t, uint32_t> currentLineByAddr;
+    std::unordered_map<uint32_t, std::string> currentFileByAddr;
 		OutputFunction Device::outputFunction = [](Computer*, uint32_t, const std::vector<Var>&){};
 	
 		void Computer::RunCode(const std::vector<ByteCode>& program, uint32_t index) {
@@ -5799,14 +5801,16 @@ const int VERSION_PATCH = 0;
 			if (program.size() <= index) return;
 			
 			// Find current file and line for debug
-			std::string currentFile = "";
-			uint32_t currentLine = 0;
+			std::string currentFile = currentFileByAddr[index];
+			uint32_t currentLine = currentLineByAddr[index];
 			for (int32_t tmpIndex = index; tmpIndex >= 0; --tmpIndex) {
 				if (currentLine == 0 && program[tmpIndex].type == LINENUMBER) {
 					currentLine = program[tmpIndex].value;
+          currentLineByAddr[index] = currentLine;
 				} else if (currentFile == "" && program[tmpIndex].type == SOURCEFILE) {
 					if (program[tmpIndex].value < assembly->sourceFiles.size()) {
 						currentFile = assembly->sourceFiles[program[tmpIndex].value];
+            currentFileByAddr[index] = currentFile;
 					}
 				} else if (currentLine != 0 && currentFile != "") {
 					break;

--- a/XenonCode.hpp
+++ b/XenonCode.hpp
@@ -5792,8 +5792,8 @@ const int VERSION_PATCH = 0;
 		std::unordered_map<uint32_t/*24 least significant bits only*/, std::string> Device::deviceFunctionNamesById {};
 		std::unordered_map<uint32_t/*24 least significant bits only*/, DeviceFunction> Device::deviceFunctionsById {};
 		std::unordered_map<uint8_t, std::vector<std::string>> Device::deviceFunctionsList {};
-    std::unordered_map<uint32_t, uint32_t> currentLineByAddr;
-    std::unordered_map<uint32_t, std::string> currentFileByAddr;
+		std::unordered_map<uint32_t, uint32_t> currentLineByAddr;
+		std::unordered_map<uint32_t, std::string> currentFileByAddr;
 		OutputFunction Device::outputFunction = [](Computer*, uint32_t, const std::vector<Var>&){};
 	
 		void Computer::RunCode(const std::vector<ByteCode>& program, uint32_t index) {
@@ -5806,11 +5806,11 @@ const int VERSION_PATCH = 0;
 			for (int32_t tmpIndex = index; tmpIndex >= 0; --tmpIndex) {
 				if (currentLine == 0 && program[tmpIndex].type == LINENUMBER) {
 					currentLine = program[tmpIndex].value;
-          currentLineByAddr[index] = currentLine;
+					currentLineByAddr[index] = currentLine;
 				} else if (currentFile == "" && program[tmpIndex].type == SOURCEFILE) {
 					if (program[tmpIndex].value < assembly->sourceFiles.size()) {
 						currentFile = assembly->sourceFiles[program[tmpIndex].value];
-            currentFileByAddr[index] = currentFile;
+						currentFileByAddr[index] = currentFile;
 					}
 				} else if (currentLine != 0 && currentFile != "") {
 					break;

--- a/XenonCode.hpp
+++ b/XenonCode.hpp
@@ -4936,6 +4936,8 @@ const int VERSION_PATCH = 0;
 		uint32_t recursion_depth = 0;
 
 		LocalVars recursive_localvars {};
+		std::unordered_map<uint32_t, uint32_t> currentLineByAddr {};
+		std::unordered_map<uint32_t, std::string> currentFileByAddr;
 		
 		std::vector<double> timersLastRun {};
 		
@@ -5235,6 +5237,9 @@ const int VERSION_PATCH = 0;
 			timersLastRun.resize(assembly->timers.size());
 			
 			recursion_depth = 0;
+
+			currentFileByAddr.clear();
+			currentLineByAddr.clear();
 			
 			return true;
 		}
@@ -5792,8 +5797,6 @@ const int VERSION_PATCH = 0;
 		std::unordered_map<uint32_t/*24 least significant bits only*/, std::string> Device::deviceFunctionNamesById {};
 		std::unordered_map<uint32_t/*24 least significant bits only*/, DeviceFunction> Device::deviceFunctionsById {};
 		std::unordered_map<uint8_t, std::vector<std::string>> Device::deviceFunctionsList {};
-		std::unordered_map<uint32_t, uint32_t> currentLineByAddr;
-		std::unordered_map<uint32_t, std::string> currentFileByAddr;
 		OutputFunction Device::outputFunction = [](Computer*, uint32_t, const std::vector<Var>&){};
 	
 		void Computer::RunCode(const std::vector<ByteCode>& program, uint32_t index) {


### PR DESCRIPTION
This PR caches function call stack trace info which removes the majority of the overhead of function calls. 
This overhead is especially pronounced in large programs because for each call the runtime scans the rest of the code above the current address looking for a filename/line label. This info can be cached per function so it only needs to be computed once. I am open to refactoring this to happen at init-time rather than lazily during execution if you'd prefer that.

The below benchmark should illustrate the reason for this change:

```xenoncode
function @padding()
	print("A")
	; ... ~2000 more lines of useless print

function @f()
	return

init
	repeat 1000000 ($i)
		@f()
```

The above takes ~27 seconds on `master`  and ~90ms on this branch when run on my M3 macbook with `-O3`.