### PR TITLE
Fixed CLANG and MSVC Compile Errors

### DIFF
--- a/XenonCode.hpp
+++ b/XenonCode.hpp
@@ -5143,7 +5143,7 @@ const int VERSION_PATCH = 0;
 	};
 
 	inline static double GetCurrentTimestamp() {
-		std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<double, std::milli>> time = std::chrono::high_resolution_clock::now();
+		std::chrono::time_point<std::chrono::system_clock, std::chrono::duration<double, std::milli>> time = std::chrono::system_clock::now();
 		return time.time_since_epoch().count() * 0.001;
 	}
 
@@ -6857,7 +6857,7 @@ const int VERSION_PATCH = 0;
 									ByteCode sep = nextCode();
 									std::string separator = sep.type != VOID? MemGetText(sep) : "";
 									if (!IsArray(arr) && !IsText(arr)) throw RuntimeError("Not an array or text");
-									auto fillArray = [&](std::vector<auto>& dst){
+									auto fillArray = [&](auto& dst){
 										dst.clear();
 										if (IsStorage(val)) {
 											auto& otherArray = GetStorage(val);


### PR DESCRIPTION
1. high_resolution_clock definition is implementation dependent per the standard.   For GCC/CLANG, it is mapped to system_clock, for MSVC is it mapped to steady_clock.    Changed high_resolution_clock to the explicit system_clock resolves the MSVC compile error.

2. The use of std::vector<auto> is an GCC feature not supported by the C++20 standard.   This results in both CLANG and MSVC compile failures.    Changing to "std::vector<auto>" to "auto" corrects the issue for both compilers.

Compiled change under g++, clang++, msvc and verified the unit test is successful (included results file comparison).