### PR TITLE
Fix seeking pass iterator end.

### DIFF
--- a/XenonCode.hpp
+++ b/XenonCode.hpp
@@ -6184,7 +6184,7 @@ const int VERSION_PATCH = 0;
 												if (obj.length() < k.length()) {
 													MemSet(obj + k + val + '}', dst);
 												} else for (auto it = obj.begin(); it != obj.end(); ++it) {
-													if (it + k.length() > obj.end()) {
+													if (std::distance(it, obj.end()) < k.length()) {
 														MemSet(obj + k + val + '}', dst);
 														break;
 													}


### PR DESCRIPTION
For a debug build under msvc/windows, the following assert is throw:

   _STL_VERIFY(static_cast<_Size_type>(_Off) <= _Left, "cannot seek string iterator after end");

Using std::distance corrects the issue.   Tested under g++/linux and msvc/windows.